### PR TITLE
Processing environment yaml sources

### DIFF
--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -216,6 +216,13 @@ class Processor
                 )
             );
             return;
+
+        // If there are sources for the environment
+        } else {
+            // Process them
+            foreach ((array) $componentConfig['env'][$this->getEnvironment()]['sources'] as $source) {
+                $component->setSource($source)->process();
+            }
         }
 
     }

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -216,13 +216,11 @@ class Processor
                 )
             );
             return;
-
-        // If there are sources for the environment
-        } else {
-            // Process them
-            foreach ((array) $componentConfig['env'][$this->getEnvironment()]['sources'] as $source) {
-                $component->setSource($source)->process();
-            }
+        }
+        
+        // If there are sources for the environment, process them
+        foreach ((array) $componentConfig['env'][$this->getEnvironment()]['sources'] as $source) {
+            $component->setSource($source)->process();
         }
 
     }


### PR DESCRIPTION
Issue #35 suggests that you should be able to specify specific source yaml files that only run on certain environments, such as a `local.yaml` with special configuration for the local environment, like so:

```
config:
  enabled: 1
  method: code
  sources:
    - ../configurator/Configuration/global.yaml
  env:
      local:
        sources:
          - ../configurator/Configuration/local.yaml
```

This didn't seem to work, however. I couldn't find any place in the code where the `process()` method was actually being called on the `['env'][$this->getEnvironment()]['sources']` array.

I added it here, and it appears to work as expected. Feel free to fix or replace this code as you see fit, but this is where the main sources are processed, and the presence of an environment `sources` array is being validated here, so it made sense to process it here after the validation.

Thank for the great module, it's just what we were looking for to set up environment specific configuration, and default categories!