### PR TITLE
Relax PHP version constraint to allow support for Magento 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "php": "~5.6.0|~7.0.0",
+    "php": "~5.6.0|~7.0",
     "symfony/yaml": ">2.8.0",
     "magento/framework": ">=100.1.0",
     "firegento/fastsimpleimport": "1.1.0",


### PR DESCRIPTION
We're currently using the Magento 2.2 RC, so far everything looks to be working, would just need the PHP version constraint relaxing as 2.2 requires 7.1