### PR TITLE
Remove object manager from Model\Processor and replace it with factory abstraction

### DIFF
--- a/Component/Factory/ComponentFactory.php
+++ b/Component/Factory/ComponentFactory.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @package  CtiDigital\Configurator
+ * @author Bartosz Herba <bartoszherba@gmail.com>
+ * @copyright 2017 CtiDigital
+ */
+
+namespace CtiDigital\Configurator\Component\Factory;
+
+use CtiDigital\Configurator\Component\ComponentAbstract;
+use Magento\Framework\ObjectManagerInterface;
+
+/**
+ * Class ComponentFactory
+ */
+class ComponentFactory implements ComponentFactoryInterface
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * ComponentFactory constructor.
+     *
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * @param string $componentClass
+     * @param array $args
+     *
+     * @return ComponentAbstract
+     */
+    public function create($componentClass, array $args = [])
+    {
+        return $this->objectManager->create($componentClass, $args);
+    }
+}

--- a/Component/Factory/ComponentFactoryInterface.php
+++ b/Component/Factory/ComponentFactoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package  CtiDigital\Configurator
+ * @author Bartosz Herba <b.herba@ctidigital.com>
+ * @copyright 2017 CtiDigital
+ */
+
+namespace CtiDigital\Configurator\Component\Factory;
+
+use CtiDigital\Configurator\Component\ComponentAbstract;
+
+/**
+ * Interface ComponentFactoryInterface
+ */
+interface ComponentFactoryInterface
+{
+    /**
+     * @param string $componentClass
+     * @param array $args
+     *
+     * @return ComponentAbstract
+     */
+    public function create($componentClass, array $args = []);
+}

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -3,16 +3,15 @@
 namespace CtiDigital\Configurator\Model;
 
 use CtiDigital\Configurator\Component\ComponentAbstract;
+use CtiDigital\Configurator\Component\Factory\ComponentFactoryInterface;
 use CtiDigital\Configurator\Model\Configurator\ConfigInterface;
 use CtiDigital\Configurator\Model\Exception\ComponentException;
-use Magento\Framework\ObjectManagerInterface;
 use Symfony\Component\Yaml\Parser;
 use Magento\Framework\App\State;
 use Magento\Framework\App\Area;
 
 class Processor
 {
-
     /**
      * @var string
      */
@@ -34,27 +33,34 @@ class Processor
     protected $log;
 
     /**
-     * @var ObjectManagerInterface
-     */
-    protected $objectManager;
-
-    /**
      * @var State
      */
     protected $state;
 
+    /**
+     * @var ComponentFactoryInterface
+     */
+    protected $componentFactory;
+
+    /**
+     * Processor constructor.
+     *
+     * @param ConfigInterface $configInterface
+     * @param ComponentFactoryInterface $componentFactory
+     * @param LoggerInterface $logging
+     * @param State $state
+     */
     public function __construct(
         ConfigInterface $configInterface,
-        ObjectManagerInterface $objectManager,
         LoggerInterface $logging,
-        State $state
+        State $state,
+        ComponentFactoryInterface $componentFactory
     ) {
         $this->log = $logging;
         $this->configInterface = $configInterface;
-        $this->objectManager = $objectManager;
         $this->state = $state;
+        $this->componentFactory = $componentFactory;
     }
-
 
     public function getLogger()
     {
@@ -175,7 +181,7 @@ class Processor
         $componentClass = $this->configInterface->getComponentByName($componentAlias);
 
         /* @var ComponentAbstract $component */
-        $component = $this->objectManager->create($componentClass);
+        $component = $this->componentFactory->create($componentClass);
         foreach ($componentConfig['sources'] as $source) {
             $component->setSource($source)->process();
         }
@@ -265,7 +271,7 @@ class Processor
         }
 
         $this->log->logComment(sprintf("The %s component has %s class name.", $componentName, $componentClass));
-        $component = $this->objectManager->create($componentClass);
+        $component = $this->componentFactory->create($componentClass);
         if ($component instanceof ComponentAbstract) {
             return true;
         }

--- a/Test/Unit/ProcessorTest.php
+++ b/Test/Unit/ProcessorTest.php
@@ -2,39 +2,55 @@
 
 namespace CtiDigital\Configurator\Model;
 
+use CtiDigital\Configurator\Component\Factory\ComponentFactory;
+use CtiDigital\Configurator\Component\Factory\ComponentFactoryInterface;
 use CtiDigital\Configurator\Model\Configurator\ConfigInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\Config\ScopeInterface;
-use Magento\Framework\ObjectManagerInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 
 class ProcessorTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var Processor
      */
     private $processor;
+
+    /**
+     * @var ConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
     private $configInterface;
-    private $objectManagerInterface;
+
+    /**
+     * @var ComponentFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockComponentFactory;
+
+    /**
+     * @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
     private $loggerInterface;
 
     protected function setUp()
     {
         $this->configInterface = $this->getMock(ConfigInterface::class);
-        $this->objectManagerInterface = $this->getMock(ObjectManagerInterface::class);
+        $this->mockComponentFactory = $this->getMockBuilder(ComponentFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+
         $consoleOutput = $this->getMock(ConsoleOutputInterface::class);
         $scopeInterface = $this->getMock(ScopeInterface::class);
         $state = $this->getMock(State::class, array(), array($scopeInterface));
         $this->loggerInterface = $this->getMock(LoggerInterface::class, array(), array(
-            $consoleOutput
+            $consoleOutput,
         ));
 
         $this->processor = $this->getMock(Processor::class, array(), array(
             $this->configInterface,
-            $this->objectManagerInterface,
             $this->loggerInterface,
-            $state
+            $state,
+            $this->mockComponentFactory,
         ));
     }
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -29,4 +29,10 @@
             <argument name="setup" xsi:type="object">CtiDigital\Configurator\Setup\Module\DataSetup</argument>
         </arguments>
     </type>
+
+    <type name="CtiDigital\Configurator\Model\Processor">
+        <arguments>
+            <argument name="componentFactory" xsi:type="object">CtiDigital\Configurator\Component\Factory\ComponentFactory</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
# Replace object manager with factory abstraction

This is an improvement with regards to https://github.com/ctidigital/magento2-configurator/issues/53

