### PR TITLE
Tax Rules fixes. Multiple Rates now work correctly. Tax Classes are n…

### DIFF
--- a/Component/TaxRules.php
+++ b/Component/TaxRules.php
@@ -165,10 +165,9 @@ class TaxRules extends CsvComponentAbstract
         $rateIds = [];
         $rateNamesArray = explode(',', $rateNames);
 
-        $rateFactory = $this->rateFactory->create()->getCollection();
         foreach ($rateNamesArray as $name) {
-            $rate = $rateFactory->addFieldToFilter('code', $name)->getFirstItem();
-
+            $rateFactory = $this->rateFactory->create()->getCollection();
+            $rate = $rateFactory->addFieldToFilter('code', $name)->load()->getFirstItem();
             $rateIds[] = $rate->getId();
         }
 
@@ -197,6 +196,7 @@ class TaxRules extends CsvComponentAbstract
                 $classModel->setClassName($name)
                     ->setClassType($type)
                     ->save();
+                $classId = $classModel->getId();
             }
 
             $taxClassIds[] = $classId;

--- a/Samples/Components/TaxRates/multi_example_taxrates.csv
+++ b/Samples/Components/TaxRates/multi_example_taxrates.csv
@@ -1,0 +1,6 @@
+Code,Country,State,Zip/Post Code,Rate,Zip/Post is Range,Range From,Range To,default
+VAT Standard Rate,GB,*,*,20,,,,
+VAT Zero Rate,GB,*,*,0,,,,
+Czech Republic,CZ,*,*,20,,,,
+Austria,AT,*,*,20,,,,
+Belgium,BE,*,*,20,,,,

--- a/Samples/Components/TaxRules/multi_example_taxrules.csv
+++ b/Samples/Components/TaxRules/multi_example_taxrules.csv
@@ -1,0 +1,3 @@
+code,tax_rate_ids,customer_tax_class_ids,product_tax_class_ids,priority,calculate_subtotal,position
+VAT Standard,"VAT Standard Rate,Czech Republic,Austria,Belgium",Retail Customer,VAT Standard,1,0,1
+VAT Zero,VAT Zero Rate,Retail Customer,VAT Zero,0,0,0


### PR DESCRIPTION
Fixes the following:
- When a new Tax Class is created, the ID is now retrieved and used in the setup. Previously it would instead create the rule and then fail with an error.
- Tax Rules with Tax Rates are now setup correctly. Previously the result of
$rate = $rateFactory->addFieldToFilter('code', $name)->getFirstItem();
was the same ID each time. 
Unfortunately this does mean having to call the create()->getCollection inside the loop.
- Examples added to samples as new files, showing multiple Tax Rates