### PR TITLE
Customer attributes

### DIFF
--- a/Component/Attributes.php
+++ b/Component/Attributes.php
@@ -62,6 +62,14 @@ class Attributes extends YamlComponentAbstract
     ];
 
     /**
+     * @var array
+     */
+    protected $skipCheck = [
+        'option',
+        'used_in_forms'
+    ];
+
+    /**
      * @var string
      */
     protected $entityTypeId = Product::ENTITY;
@@ -147,7 +155,7 @@ class Attributes extends YamlComponentAbstract
 
             $name = $this->mapAttributeConfig($name);
 
-            if ($name == 'option') {
+            if (in_array($name, $this->skipCheck)) {
                 continue;
             }
             if (!array_key_exists($name, $attributeArray)) {

--- a/Component/CustomerAttributes.php
+++ b/Component/CustomerAttributes.php
@@ -6,8 +6,12 @@ use CtiDigital\Configurator\Api\LoggerInterface;
 use CtiDigital\Configurator\Exception\ComponentException;
 use Magento\Customer\Model\Customer;
 use Magento\Eav\Setup\EavSetup;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Eav\Model\AttributeRepository;
+use Magento\Customer\Setup\CustomerSetupFactory;
+use Magento\Customer\Setup\CustomerSetup;
+use Magento\Customer\Model\ResourceModel\Attribute;
 
 /**
  * Class CustomerAttributes
@@ -16,6 +20,9 @@ use Magento\Eav\Model\AttributeRepository;
  */
 class CustomerAttributes extends Attributes
 {
+    const DEFAULT_ATTRIBUTE_SET_ID = 1;
+    const DEFAULT_ATTRIBUTE_GROUP_ID = 1;
+
     protected $alias = 'customer_attributes';
     protected $name = 'Customer Attributes';
     protected $description = 'Component to create/maintain customer attributes.';
@@ -30,13 +37,27 @@ class CustomerAttributes extends Attributes
         'position' => 'sort_order'
     ];
 
+    /**
+     * @var CustomerSetupFactory
+     */
+    protected $customerSetup;
+
+    /**
+     * @var Attribute
+     */
+    protected $attributeResource;
+
     public function __construct(
         LoggerInterface $log,
         ObjectManagerInterface $objectManager,
         EavSetup $eavSetup,
-        AttributeRepository $attributeRepository
+        AttributeRepository $attributeRepository,
+        CustomerSetupFactory $customerSetupFactory,
+        Attribute $attributeResource
     ) {
         $this->attributeConfigMap = array_merge($this->attributeConfigMap, $this->customerConfigMap);
+        $this->customerSetup = $customerSetupFactory;
+        $this->attributeResource = $attributeResource;
         parent::__construct($log, $objectManager, $eavSetup, $attributeRepository);
     }
 
@@ -48,9 +69,51 @@ class CustomerAttributes extends Attributes
         try {
             foreach ($attributeConfigurationData['customer_attributes'] as $attributeCode => $attributeConfiguration) {
                 $this->processAttribute($attributeCode, $attributeConfiguration);
+                $this->addAdditionalValues($attributeCode, $attributeConfiguration);
             }
         } catch (ComponentException $e) {
             $this->log->logError($e->getMessage());
+        }
+    }
+
+    /**
+     * Adds necessary additional values to the attribute. Without these, values can't be saved
+     * to the attribute and it won't appear in any forms.
+     *
+     * @param $attributeCode
+     * @param $attributeConfiguration
+     */
+    protected function addAdditionalValues($attributeCode, $attributeConfiguration)
+    {
+        $data = [
+            'attribute_set_id' => self::DEFAULT_ATTRIBUTE_SET_ID,
+            'attribute_group_id' => self::DEFAULT_ATTRIBUTE_GROUP_ID
+        ];
+        if (isset($attributeConfiguration['used_in_forms']) &&
+            isset($attributeConfiguration['used_in_forms']['values'])) {
+            $data['used_in_forms'] = $attributeConfiguration['used_in_forms']['values'];
+        }
+        /** @var CustomerSetup $customerSetup */
+        $customerSetup = $this->customerSetup->create();
+        try {
+            $attribute = $customerSetup->getEavConfig()
+                ->getAttribute($this->entityTypeId, $attributeCode)
+                ->addData($data);
+        } catch (LocalizedException $e) {
+            $this->log->logError(sprintf(
+                'Error applying additional values to %s: %s',
+                $attributeCode,
+                $e->getMessage()
+            ));
+        }
+        try {
+            $this->attributeResource->save($attribute);
+        } catch (\Exception $e) {
+            $this->log->logError(sprintf(
+                'Error saving additional values for %s: %s',
+                $attributeCode,
+                $e->getMessage()
+            ));
         }
     }
 }


### PR DESCRIPTION
Issues were discovered when using the customer attributes component:
- **Created attributes weren't being added to forms (for frontend and backend use)**
The component should now add the attribute to any forms specified in the component YAML file. If no forms are specified, the attribute will be added to every applicable form by default.
- **Customer CSV data import would fail when trying to add values to created attributes**
This was due to the attributes not being added to the default attribute set and to the general attribute group. The component will now add created attributes to the appropriate set and group.