### PR TITLE
Absolute path for csv parseData

### DIFF
--- a/Component/CsvComponentAbstract.php
+++ b/Component/CsvComponentAbstract.php
@@ -47,7 +47,8 @@ abstract class CsvComponentAbstract extends ComponentAbstract
             $file = new File();
             $parser = new Csv($file);
 
-            return $parser->getData($source);
+            $path = BP . '/' . $source;
+            return $parser->getData($path);
 
         } catch (ComponentException $e) {
             $this->log->logError($e->getMessage());

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "symfony/yaml": ">2.8.0",
-    "firegento/fastsimpleimport": "1.1.0"
+    "firegento/fastsimpleimport": "dev-master"
   },
   "require-dev": {
     "phpmd/phpmd": "^2.6",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "symfony/yaml": ">2.8.0",
-    "firegento/fastsimpleimport": "dev-master"
+    "firegento/fastsimpleimport": "~v1.0"
   },
   "require-dev": {
     "phpmd/phpmd": "^2.6",


### PR DESCRIPTION
As for the class YamlComponentAbstract.php I added the absolute path for the class CsvComponentAbstract.php

Currently when I load taxes from the csv this error is generated:
![path-bug-screen](https://user-images.githubusercontent.com/7668223/38570220-a037e696-3ced-11e8-833e-fef968f76d22.JPG)
