### PR TITLE
Add Support for Magento 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ env:
       MAGE_VERSION=2.2.5
     - TEST_SUITE=configurator
       MAGE_VERSION=2.2.6
-
+    - TEST_SUITE=configurator
+      MAGE_VERSION=2.3.0
 matrix:
   allow_failures:
     - php: 7.0

--- a/Test/Integration/setup-magento.sh
+++ b/Test/Integration/setup-magento.sh
@@ -16,9 +16,11 @@ git checkout tags/$1 -b $1
 
 composer install
 
-echo Temporary change versions to attempt to resolve any dependency issue
-composer require symfony/config:4.1.*
-composer require symfony/dependency-injection:3.3.*
+if [ $(php -r "echo (int) version_compare('$1', '2.3.0', '<');") == '1' ]; then
+    echo Temporary change versions to attempt to resolve any dependency issue
+    composer require symfony/config:4.1.*
+    composer require symfony/dependency-injection:3.3.* 
+fi
 
 if [ -z "${TRAVIS_TAG}" ]; then
     echo Require configurator branch: ${TRAVIS_BRANCH} commit: ${TRAVIS_COMMIT}

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "symfony/yaml": "3.3.*",
+    "symfony/yaml": "~3.3",
     "firegento/fastsimpleimport": "1.3.0"
   },
   "require-dev": {


### PR DESCRIPTION
Hi,

Magento 2.3 seems to need a higher version of the `symfony/yaml`package. So I have updated the package version constraint.

According to the composer documentation `"symfony/yaml": "~3.3"` should not break anything, it allows Versions from `>=3.3.0` and `<4.0.0`.  

Could you review the changes and and create a new Version, so that the extension can be installed in Magento 2.3 System?

Thanks!