### PR TITLE
Corrected global attribute setting example

### DIFF
--- a/Samples/Components/Attributes/attributes.yaml
+++ b/Samples/Components/Attributes/attributes.yaml
@@ -1,6 +1,6 @@
 attributes:
   test_attr:
-    is_global: 1
+    global: 1
     label: Test Attribute
     type: text
     input: select


### PR DESCRIPTION
Using 'is_global' in the attributes YAML file doesn't set the scope of the attribute. 'global' has the desired effect.