### PR TITLE
Fix #105 - New option values ignored on change

### DIFF
--- a/Component/Attributes.php
+++ b/Component/Attributes.php
@@ -115,6 +115,9 @@ class Attributes extends YamlComponentAbstract
 
             if (isset($attributeConfig['option'])) {
                 $newAttributeOptions = $this->manageAttributeOptions($attributeCode, $attributeConfig['option']);
+                if(!empty($newAttributeOptions)) {
+                    $updateAttribute = true;   
+                }
                 $attributeConfig['option']['values'] = $newAttributeOptions;
             }
         }

--- a/Component/Attributes.php
+++ b/Component/Attributes.php
@@ -115,8 +115,8 @@ class Attributes extends YamlComponentAbstract
 
             if (isset($attributeConfig['option'])) {
                 $newAttributeOptions = $this->manageAttributeOptions($attributeCode, $attributeConfig['option']);
-                if(!empty($newAttributeOptions)) {
-                    $updateAttribute = true;   
+                if (!empty($newAttributeOptions)) {
+                    $updateAttribute = true;
                 }
                 $attributeConfig['option']['values'] = $newAttributeOptions;
             }


### PR DESCRIPTION
Fixes issue where option values are not updated unless another attribute not in the $skipCheck array is changed as well.