### PR TITLE
Issue with updating customer attributes

### DIFF
--- a/Component/CustomerAttributes.php
+++ b/Component/CustomerAttributes.php
@@ -98,6 +98,9 @@ class CustomerAttributes extends Attributes
      */
     protected function addAdditionalValues($attributeCode, $attributeConfiguration)
     {
+        if ($this->attributeExists) {
+            return;
+        }
         if (!isset($attributeConfiguration['used_in_forms']) ||
             !isset($attributeConfiguration['used_in_forms']['values'])) {
             $attributeConfiguration['used_in_forms'] = $this->defaultForms;


### PR DESCRIPTION
When trying to update a customer attribute, the addAdditionalValues method reverts the attribute settings. I've made some changes to make the Attribute class's `$attributeExists` available to the CustomerAttributes class, so it can tell whether the current attribute is new or an update. 

Also noted the frontend_model wasn't applying to customer attributes, so I added it to the attribute config map.