### PR TITLE
[FEATURE] - SQL Multi-line Queries

### DIFF
--- a/Component/Sql.php
+++ b/Component/Sql.php
@@ -75,8 +75,7 @@ class Sql extends YamlComponentAbstract
                 $this->log->logError("{$path} does not exist. Skipping.");
                 continue;
             }
-            $fileContent = file_get_contents($path);
-            $this->processor->process($name, $fileContent);
+            $this->processor->process($name, $path);
         }
     }
 }


### PR DESCRIPTION
The following PR amends the SQL configuration to allow SQL files to be parsed when containing queries that spread multiple lines.

SUMMARY:
* Parses and splits SQL queries that are spread across multiple lines.
* Ignores quoted and escaped semi-colons to prevent breakages