### PR TITLE
Amend unit test to use file contents and path

### DIFF
--- a/Component/Processor/SqlSplitProcessor.php
+++ b/Component/Processor/SqlSplitProcessor.php
@@ -92,6 +92,7 @@ class SqlSplitProcessor
      */
     private function extractQueriesFromFile($filePath, $delimiter = ';')
     {
+        $obBaseLevel = ob_get_level();
         $queries = [];
         $file = fopen($filePath, 'r');
         if (is_resource($file) === true) {
@@ -104,7 +105,7 @@ class SqlSplitProcessor
 
                     $queries[] = $query;
 
-                    while (ob_get_level() > 0) {
+                    while (ob_get_level() > $obBaseLevel) {
                         ob_end_flush();
                     }
                     flush();

--- a/Test/Unit/Processor/SqlSplitProcessorTest.php
+++ b/Test/Unit/Processor/SqlSplitProcessorTest.php
@@ -21,6 +21,8 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
  */
 class SqlSplitProcessorTest extends \PHPUnit\Framework\TestCase
 {
+    const TEST_SQL_PATH = '/Unit/_files/sql/test.sql';
+
     /**
      * @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
@@ -85,7 +87,6 @@ class SqlSplitProcessorTest extends \PHPUnit\Framework\TestCase
     public function testExceptionHandling()
     {
         $name = 'name1';
-        $fileContent = 'SELECT * FROM unknown';
         $exMsg = 'exception message';
 
         $this->mockConnection
@@ -102,6 +103,6 @@ class SqlSplitProcessorTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('rollBack');
 
-        $this->processor->process($name, $fileContent);
+        $this->processor->process($name, dirname(dirname(__DIR__)) . self::TEST_SQL_PATH);
     }
 }

--- a/Test/Unit/_files/sql/test.sql
+++ b/Test/Unit/_files/sql/test.sql
@@ -1,0 +1,1 @@
+SELECT * FROM unknown;


### PR DESCRIPTION
* Amended file reader to check base output buffer level, and use this when flushing in the while loop to ensure that it doesn't flush beyond the level at the entry point of the function (issue raised during unit tests)
* Added SQL file for Unit test
* Amended unit to pass file path for unit test