### PR TITLE
Use content type instead of extension for remote sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ env:
     - TEST_SUITE=unit
     - TEST_SUITE=phpcs
     - TEST_SUITE=configurator
-    - TEST_SUITE=configurator
       MAGE_VERSION=2.3.6
     - TEST_SUITE=configurator
       MAGE_VERSION=2.4.1
 
 before_install:
   - phpenv config-rm xdebug.ini || true
+  - composer self-update --1
   - echo "{\"http-basic\":{\"repo.magento.com\":{\"username\":\"${MAGENTO_USERNAME}\",\"password\":\"${MAGENTO_PASSWORD}\"}}}" > auth.json
   - sh -c "if [ '$TEST_SUITE' = 'phpcs' ]; then composer require magento/framework:^103.0.1; fi"
   - sh -c "if [ '$TEST_SUITE' = 'unit' ]; then composer require magento/framework:^103.0.1; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: trusty
 language: php
 php:
-  - 7.2
   - 7.3
 services:
   - mysql
@@ -11,20 +10,10 @@ env:
     - TEST_SUITE=unit
     - TEST_SUITE=phpcs
     - TEST_SUITE=configurator
-      MAGE_VERSION=2.2.5
     - TEST_SUITE=configurator
-      MAGE_VERSION=2.3.1
+      MAGE_VERSION=2.3.6
     - TEST_SUITE=configurator
-      MAGE_VERSION=2.3.2
-    - TEST_SUITE=configurator
-      MAGE_VERSION=2.3.3
-
-matrix:
-  allow_failures:
-    - php: 7.2
-    - env: TEST_SUITE=configurator MAGE_VERSION=2.2.5
-    - env: TEST_SUITE=configurator MAGE_VERSION=2.3.1
-    - env: TEST_SUITE=configurator MAGE_VERSION=2.3.2
+      MAGE_VERSION=2.4.1
 
 before_install:
   - echo "{\"http-basic\":{\"repo.magento.com\":{\"username\":\"${MAGENTO_USERNAME}\",\"password\":\"${MAGENTO_PASSWORD}\"}}}" > auth.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
       MAGE_VERSION=2.4.1
 
 before_install:
+  - phpenv config-rm xdebug.ini || true
   - echo "{\"http-basic\":{\"repo.magento.com\":{\"username\":\"${MAGENTO_USERNAME}\",\"password\":\"${MAGENTO_PASSWORD}\"}}}" > auth.json
   - sh -c "if [ '$TEST_SUITE' = 'phpcs' ]; then composer require magento/framework:^103.0.1; fi"
   - sh -c "if [ '$TEST_SUITE' = 'unit' ]; then composer require magento/framework:^103.0.1; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
     - TEST_SUITE=unit
     - TEST_SUITE=phpcs
     - TEST_SUITE=configurator
-      MAGE_VERSION=2.3.6
-    - TEST_SUITE=configurator
       MAGE_VERSION=2.4.1
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.3
 services:
   - mysql
+  - elasticsearch
 sudo: required
 env:
   matrix:

--- a/Component/Product/Validator.php
+++ b/Component/Product/Validator.php
@@ -79,10 +79,20 @@ class Validator
         $productIdentifierMessage = ($sku !== null) ? sprintf('SKU: %s', $sku) : sprintf('Row Number : %s', $row);
         switch ($type) {
             case self::IMPORT_DATA_ACTION_NULLIFY:
-                $message = sprintf('%s Error: %s Resolution: Unset the value for attribute code %s', $productIdentifierMessage, $errorMessage, $attributeCode);
+                $message = sprintf(
+                    '%s Error: %s Resolution: Unset the value for attribute code %s',
+                    $productIdentifierMessage,
+                    $errorMessage,
+                    $attributeCode
+                );
                 break;
             default:
-                $message = sprintf('%s Error: %s Resolution: Removed the row due to error with attribute code %s', $productIdentifierMessage, $errorMessage, $attributeCode);
+                $message = sprintf(
+                    '%s Error: %s Resolution: Removed the row due to error with attribute code %s',
+                    $productIdentifierMessage,
+                    $errorMessage,
+                    $attributeCode
+                );
                 $this->removedRows[$row] = $message;
                 break;
         }
@@ -146,13 +156,25 @@ class Validator
                 switch ($failedRow['action']) {
                     case self::IMPORT_DATA_ACTION_NULLIFY:
                         if (isset($importLines[$row][$attributeCode])) {
-                            $this->writeLog($importLines[$row], $row, $attributeCode, $failedRow['message'], self::IMPORT_DATA_ACTION_NULLIFY);
+                            $this->writeLog(
+                                $importLines[$row],
+                                $row,
+                                $attributeCode,
+                                $failedRow['message'],
+                                self::IMPORT_DATA_ACTION_NULLIFY
+                            );
                             $importLines[$row][$attributeCode] = null;
                         }
                         break;
                     default:
                         if (isset($importLines[$row])) {
-                            $this->writeLog($importLines[$row], $row, $attributeCode, $failedRow['message'], self::IMPORT_DATA_ACTION_REMOVE);
+                            $this->writeLog(
+                                $importLines[$row],
+                                $row,
+                                $attributeCode,
+                                $failedRow['message'],
+                                self::IMPORT_DATA_ACTION_REMOVE
+                            );
                             unset($importLines[$row]);
                         }
                 }
@@ -194,7 +216,9 @@ class Validator
         }, $rows);
 
         $attributeCode = $this->getAttributeCodeFromError($error);
-        $action = (in_array($attributeCode, self::ATTRIBUTES_NULLIFY_ALLOW_LIST)) ? self::IMPORT_DATA_ACTION_NULLIFY : self::IMPORT_DATA_ACTION_REMOVE;
+        $action = (in_array($attributeCode, self::ATTRIBUTES_NULLIFY_ALLOW_LIST)) ?
+            self::IMPORT_DATA_ACTION_NULLIFY :
+            self::IMPORT_DATA_ACTION_REMOVE;
 
         return [
             'action' => $action,

--- a/Component/Product/Validator.php
+++ b/Component/Product/Validator.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace CtiDigital\Configurator\Component\Product;
+
+use CtiDigital\Configurator\Component\Products;
+use Firegento\FastSimpleImport\Model\Importer;
+use FireGento\FastSimpleImport\Model\Adapters\ImportAdapterFactoryInterface;
+
+class Validator
+{
+    /**
+     * Product import attributes which can be nulled if the data is not in a valid format
+     */
+    const ATTRIBUTES_NULLIFY_ALLOW_LIST = [
+        'image',
+        'small_image',
+        'thumbnail',
+        'additional_images',
+    ];
+
+    /**
+     * Indicate that the row data should be removed entirely
+     */
+    const IMPORT_DATA_ACTION_REMOVE = 'remove';
+
+    /**
+     * Indicate that the attribute that's failing to import should be set to 'null'
+     */
+    const IMPORT_DATA_ACTION_NULLIFY = 'nullify';
+
+    /**
+     * @var ImportAdapterFactoryInterface
+     */
+    private $importAdapterFactory;
+
+    /**
+     * @var array
+     */
+    private $logs = [];
+
+    private $removedRows = [];
+
+    /**
+     * Validator constructor.
+     * @param ImportAdapterFactoryInterface $importAdapterFactory
+     */
+    public function __construct(
+        ImportAdapterFactoryInterface $importAdapterFactory
+    ) {
+        $this->importAdapterFactory = $importAdapterFactory;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLogs()
+    {
+        return $this->logs;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRemovedRows()
+    {
+        return $this->removedRows;
+    }
+
+    /**
+     * @param $rowData
+     * @param $row
+     * @param $attributeCode
+     * @param $errorMessage
+     * @param string $type
+     */
+    private function writeLog($rowData, $row, $attributeCode, $errorMessage, $type = self::IMPORT_DATA_ACTION_REMOVE)
+    {
+        $sku = isset($rowData['sku']) ? $rowData['sku'] : null;
+        $productIdentifierMessage = ($sku !== null) ? sprintf('SKU: %s', $sku) : sprintf('Row Number : %s', $row);
+        switch ($type) {
+            case self::IMPORT_DATA_ACTION_NULLIFY:
+                $message = sprintf('%s Error: %s Resolution: Unset the value for attribute code %s', $productIdentifierMessage, $errorMessage, $attributeCode);
+                break;
+            default:
+                $message = sprintf('%s Error: %s Resolution: Removed the row due to error with attribute code %s', $productIdentifierMessage, $errorMessage, $attributeCode);
+                $this->removedRows[$row] = $message;
+                break;
+        }
+        $this->logs[] = $message;
+    }
+
+    /**
+     * Runs the import data through the validation steps and returns the modified values
+     *
+     * @param Importer $import
+     * @param $importLines
+     * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getValidatedImport(Importer $import, $importLines)
+    {
+        $this->logs = [];
+        $failedImportRows = $this->getImportRowFailures($import, $importLines);
+        $importLines = $this->omitItemsFromImport($importLines, $failedImportRows);
+        return $importLines;
+    }
+
+    /**
+     * @param Importer $import
+     * @param $importLines
+     * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getImportRowFailures(Importer $import, $importLines)
+    {
+        $failedRows = [];
+        // Creates a validation model and runs the import data through so we can find which rows would fail
+        $validation = $import->createImportModel();
+        $validationSource = $this->importAdapterFactory->create([
+            'data' => $importLines,
+            'multipleValueSeparator' => Products::SEPARATOR
+        ]);
+        $validation->validateSource($validationSource);
+        $errors = $validation->getErrorAggregator();
+        foreach ($errors->getRowsGroupedByErrorCode() as $error => $rows) {
+            if (is_array($rows)) {
+                $failedRow = $this->formatRowRemoveData($error, $rows);
+                $failedRows[] = $failedRow;
+            }
+        }
+        return $failedRows;
+    }
+
+    /**
+     * Either removes a row entirely or nulls specific attributes that we know are okay to ignore
+     *
+     * @param array $importLines
+     * @param array $failedRows
+     * @return array
+     */
+    public function omitItemsFromImport(array $importLines, array $failedRows)
+    {
+        foreach ($failedRows as $failedRow) {
+            $attributeCode = $failedRow['attribute_code'];
+            foreach ($failedRow['rows'] as $row) {
+                switch ($failedRow['action']) {
+                    case self::IMPORT_DATA_ACTION_NULLIFY:
+                        if (isset($importLines[$row][$attributeCode])) {
+                            $this->writeLog($importLines[$row], $row, $attributeCode, $failedRow['message'], self::IMPORT_DATA_ACTION_NULLIFY);
+                            $importLines[$row][$attributeCode] = null;
+                        }
+                        break;
+                    default:
+                        if (isset($importLines[$row])) {
+                            $this->writeLog($importLines[$row], $row, $attributeCode, $failedRow['message'], self::IMPORT_DATA_ACTION_REMOVE);
+                            unset($importLines[$row]);
+                        }
+                }
+            }
+        }
+        $importLines = array_values($importLines);
+        return $importLines;
+    }
+
+    /**
+     * Gets the attribute code from the error returned by the validator
+     *
+     * @param $error
+     * @return string|null
+     */
+    public function getAttributeCodeFromError($error)
+    {
+        $matches = [];
+        $attributeCode = null;
+        preg_match('/attribute\s([^\s]*)/', $error, $matches);
+        if (isset($matches[1])) {
+            $attributeCode = $matches[1];
+        }
+        return $attributeCode;
+    }
+
+    /**
+     * Processes the error into a set format
+     *
+     * @param $error
+     * @param $rows
+     * @return array
+     */
+    private function formatRowRemoveData($error, $rows)
+    {
+        // Magento increases the row number by 1 as it assumes you've uploaded a CSV file with a header
+        $rowsProcessed = array_map(function ($row) {
+            return $row - 1;
+        }, $rows);
+
+        $attributeCode = $this->getAttributeCodeFromError($error);
+        $action = (in_array($attributeCode, self::ATTRIBUTES_NULLIFY_ALLOW_LIST)) ? self::IMPORT_DATA_ACTION_NULLIFY : self::IMPORT_DATA_ACTION_REMOVE;
+
+        return [
+            'action' => $action,
+            'message' => $error,
+            'rows' => $rowsProcessed,
+            'attribute_code' => $attributeCode
+        ];
+    }
+}

--- a/Component/Product/Validator.php
+++ b/Component/Product/Validator.php
@@ -76,12 +76,12 @@ class Validator
     private function writeLog($rowData, $row, $attributeCode, $errorMessage, $type = self::IMPORT_DATA_ACTION_REMOVE)
     {
         $sku = isset($rowData['sku']) ? $rowData['sku'] : null;
-        $productIdentifierMessage = ($sku !== null) ? sprintf('SKU: %s', $sku) : sprintf('Row Number : %s', $row);
+        $identifierMessage = ($sku !== null) ? sprintf('SKU: %s', $sku) : sprintf('Row Number : %s', $row);
         switch ($type) {
             case self::IMPORT_DATA_ACTION_NULLIFY:
                 $message = sprintf(
                     '%s Error: %s Resolution: Unset the value for attribute code %s',
-                    $productIdentifierMessage,
+                    $identifierMessage,
                     $errorMessage,
                     $attributeCode
                 );
@@ -89,7 +89,7 @@ class Validator
             default:
                 $message = sprintf(
                     '%s Error: %s Resolution: Removed the row due to error with attribute code %s',
-                    $productIdentifierMessage,
+                    $identifierMessage,
                     $errorMessage,
                     $attributeCode
                 );

--- a/Component/Products.php
+++ b/Component/Products.php
@@ -195,13 +195,13 @@ class Products implements ComponentInterface
          * @var Validator $validatorModel
          */
         $validatorModel = $this->validatorFactory->create();
-        $validatedProductsArray = $validatorModel->getValidatedImport($validatorImport, $productsArray);
+        $validatedProducts = $validatorModel->getValidatedImport($validatorImport, $productsArray);
         $this->log->logInfo(sprintf('Removed %s products after validation.', count($validatorModel->getRemovedRows())));
-        $this->log->logInfo(sprintf('Attempting to import %s rows', count($validatedProductsArray)));
+        $this->log->logInfo(sprintf('Attempting to import %s rows', count($validatedProducts)));
         try {
             $import = $this->importerFactory->create();
             $import->setMultipleValueSeparator(self::SEPARATOR);
-            $import->processImport($validatedProductsArray);
+            $import->processImport($validatedProducts);
         } catch (\Exception $e) {
             $this->log->logError($e->getMessage());
         }
@@ -260,6 +260,7 @@ class Products implements ComponentInterface
 
     /**
      * Create the configurable product string
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      *
      * @param $data
      * @return string

--- a/Component/Products.php
+++ b/Component/Products.php
@@ -275,7 +275,7 @@ class Products implements ComponentInterface
                 $productsCount = count($products);
                 $count = 0;
                 foreach ($products as $sku) {
-                    if ($count > $productsCount) {
+                    if ($count > 0 && $count < $productsCount) {
                         $variations .= '|';
                     }
                     $productModel = $this->productFactory->create();

--- a/Component/Products.php
+++ b/Component/Products.php
@@ -165,9 +165,11 @@ class Products implements ComponentInterface
             }
             if ($this->isConfigurable($productArray)) {
                 $variations = $this->constructConfigurableVariations($productArray);
-                if (strlen($variations) > 0) {
-                    $productArray['configurable_variations'] = $variations;
+                if (strlen($variations) === 0) {
+                    $this->skippedProducts[] = $product[$this->skuColumn];
+                    continue;
                 }
+                $productArray['configurable_variations'] = $variations;
                 unset($productArray['associated_products']);
                 unset($productArray['configurable_attributes']);
             }
@@ -273,6 +275,9 @@ class Products implements ComponentInterface
                 $productsCount = count($products);
                 $count = 0;
                 foreach ($products as $sku) {
+                    if ($count > $productsCount) {
+                        $variations .= '|';
+                    }
                     $productModel = $this->productFactory->create();
                     $id = $productModel->getIdBySku($sku);
                     $productModel->load($id);
@@ -283,9 +288,6 @@ class Products implements ComponentInterface
                             $variations .= 'sku=' . $sku . self::SEPARATOR . $configSkuAttributes;
                         }
                         $count++;
-                        if ($count < $productsCount) {
-                            $variations .= '|';
-                        }
                     }
                 }
             }

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -548,6 +548,7 @@ class Processor
             $csvData[] = $csvRow;
         }
 
+        fclose($handle);
         return $csvData;
     }
 

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -436,7 +436,7 @@ class Processor
 
         // For remote files, use the mime type to determine the extension
         if ($this->isRemoteSource($source)) {
-          $extension = $this->getRemoteContentExtension($source);
+            $extension = $this->getRemoteContentExtension($source);
         }
 
         if (strtolower($extension) === 'yaml') {
@@ -470,20 +470,20 @@ class Processor
      */
     private function getRemoteContentExtension($source)
     {
-      try {
-          // phpcs:ignore Magento2.Functions.DiscouragedFunction
-          $streamContext = stream_context_create(['ssl' => ['verify_peer' => false, 'verify_peer_name' => false]]);
-      } catch (\Exception $e) {
-          return '';
-      }
+        try {
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            $streamContext = stream_context_create(['ssl' => ['verify_peer' => false, 'verify_peer_name' => false]]);
+        } catch (\Exception $e) {
+            return '';
+        }
 
-      // phpcs:ignore Magento2.Functions.DiscouragedFunction
-      $headers = get_headers($source, 1);
-      $contentType = array_key_exists('Content-Type', $headers) ? $headers['Content-Type'] : '';
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction
+        $headers = get_headers($source, 1);
+        $contentType = array_key_exists('Content-Type', $headers) ? $headers['Content-Type'] : '';
 
-      // Parse the 'extension' from the content type
-      preg_match('%^text/([a-z]+)%', $contentType, $matches);
-      return (count($matches) == 2) ? $matches[1] : null;
+        // Parse the 'extension' from the content type
+        preg_match('%^text/([a-z]+)%', $contentType, $matches);
+        return (count($matches) == 2) ? $matches[1] : null;
     }
 
     /**

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -433,6 +433,12 @@ class Processor
     {
         // phpcs:ignore Magento2.Functions.DiscouragedFunction
         $extension = pathinfo($source, PATHINFO_EXTENSION);
+
+        // For remote files, use the mime type to determine the extension
+        if ($this->isRemoteSource($source)) {
+          $extension = $this->getRemoteContentExtension($source);
+        }
+
         if (strtolower($extension) === 'yaml') {
             return self::SOURCE_YAML;
         }
@@ -455,6 +461,29 @@ class Processor
         return ($this->isSourceRemote($source) === true) ?
             $this->getRemoteData($source) :
             file_get_contents(BP . '/' . $source); // phpcs:ignore Magento2.Functions.DiscouragedFunction
+    }
+
+    /**
+     * @param $source
+     * @return array|bool|false|float|int|mixed|string|null
+     * @throws \Exception
+     */
+    private function getRemoteContentExtension($source)
+    {
+      try {
+          // phpcs:ignore Magento2.Functions.DiscouragedFunction
+          $streamContext = stream_context_create(['ssl' => ['verify_peer' => false, 'verify_peer_name' => false]]);
+      } catch (\Exception $e) {
+          return '';
+      }
+
+      // phpcs:ignore Magento2.Functions.DiscouragedFunction
+      $headers = get_headers($source, 1);
+      $contentType = array_key_exists('Content-Type', $headers) ? $headers['Content-Type'] : '';
+
+      // Parse the 'extension' from the content type
+      preg_match('%^text/([a-z]+)%', $contentType, $matches);
+      return (count($matches) == 2) ? $matches[1] : null;
     }
 
     /**

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -524,9 +524,7 @@ class Processor
     private function parseCsvData($source)
     {
         // Get a handle to the source data, whether it's remote or local
-        $remoteSource = $this->isSourceRemote($source);
-
-        if ($remoteSource) {
+        if ($this->isSourceRemote($source)) {
             // phpcs:ignore Magento2.Functions.DiscouragedFunction
             $streamContext = stream_context_create(['ssl' => ['verify_peer' => false, 'verify_peer_name' => false]]);
             $handle = fopen($source, 'r', false, $streamContext);

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -520,10 +520,9 @@ class Processor
 
     /**
      * @param $source
-     * @return array
-     * @throws \Exception
+     * @return mixed
      */
-    private function parseCsvData($source)
+    private function getFileHandle($source)
     {
         // Get a handle to the source data, whether it's remote or local
         if ($this->isSourceRemote($source)) {
@@ -537,14 +536,24 @@ class Processor
                 ]);
 
                 // phpcs:ignore Magento2.Functions.DiscouragedFunction
-                $handle = fopen($source, 'r', false, $streamContext);
+                return fopen($source, 'r', false, $streamContext);
             } catch (Exception $ex) {
                 throw new ComponentException("Can't open CSV source for reading: {$ex->getMessage()}");
             }
-        } else {
-            // phpcs:ignore Magento2.Functions.DiscouragedFunction
-            $handle = fopen($source, 'r');
         }
+
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction
+        return fopen($source, 'r');
+    }
+
+    /**
+     * @param $source
+     * @return array
+     * @throws \Exception
+     */
+    private function parseCsvData($source)
+    {
+        $handle = $this->getFileHandle($source);
 
         // Read the header row
         // phpcs:ignore Magento2.Functions.DiscouragedFunction

--- a/Test/Unit/Component/ProductsTest.php
+++ b/Test/Unit/Component/ProductsTest.php
@@ -8,6 +8,7 @@ use Magento\Catalog\Model\Product;
 use CtiDigital\Configurator\Component\Product\Image;
 use CtiDigital\Configurator\Component\Product\AttributeOption;
 use CtiDigital\Configurator\Api\LoggerInterface;
+use CtiDigital\Configurator\Component\Product\ValidatorFactory;
 use Magento\Eav\Model\Entity\Attribute;
 
 class ProductsTest extends \PHPUnit\Framework\TestCase
@@ -42,6 +43,11 @@ class ProductsTest extends \PHPUnit\Framework\TestCase
      */
     private $log;
 
+    /**
+     * @var ValidatorFactory|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $validatorFactory;
+
     protected function setUp()
     {
         $this->importerFactory = $this->getMockBuilder(ImporterFactory::class)
@@ -65,10 +71,15 @@ class ProductsTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->validatorFactory = $this->getMockBuilder(ValidatorFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->products = new Products(
             $this->importerFactory,
             $this->productFactory,
             $this->image,
+            $this->validatorFactory,
             $this->attributeOption,
             $this->log
         );


### PR DESCRIPTION
For remote files, check the content type of the file rather than attemping to parse the extension from the URL. This allows query string parameters to be used.

When importing CSV data, use fgetcsv() to cater for line breaks within fields.