### PR TITLE
Update firegento/fastsimpleimport required version

### DIFF
--- a/Component/Product/Image.php
+++ b/Component/Product/Image.php
@@ -4,7 +4,7 @@ namespace CtiDigital\Configurator\Component\Product;
 use CtiDigital\Configurator\Api\LoggerInterface;
 use Magento\Framework\Filesystem;
 use Magento\Framework\App\Filesystem\DirectoryList;
-use FireGento\FastSimpleImport\Helper\Config;
+use FireGento\FastSimpleImport\Model\Config;
 use Magento\Framework\HTTP\ZendClient;
 use Magento\Framework\HTTP\ZendClientFactory;
 

--- a/Test/Unit/Component/Product/ImageTest.php
+++ b/Test/Unit/Component/Product/ImageTest.php
@@ -3,7 +3,7 @@ namespace CtiDigital\Configurator\Test\Unit\Component\Product;
 
 use CtiDigital\Configurator\Component\Product\Image;
 use Magento\Framework\Filesystem;
-use FireGento\FastSimpleImport\Helper\Config;
+use FireGento\FastSimpleImport\Model\Config;
 use Magento\Framework\HTTP\ZendClient;
 use Magento\Framework\HTTP\ZendClientFactory;
 use CtiDigital\Configurator\Api\LoggerInterface;

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "symfony/yaml": "~4.0|~5.0",
-    "firegento/fastsimpleimport": "1.3.4"
+    "firegento/fastsimpleimport": "^1.3.4|^2.0"
   },
   "require-dev": {
     "phpmd/phpmd": "^2.6",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "symfony/yaml": "~4.0|~5.0",
-    "firegento/fastsimpleimport": "^1.3.4|^2.0"
+    "firegento/fastsimpleimport": "^2.0"
   },
   "require-dev": {
     "phpmd/phpmd": "^2.6",


### PR DESCRIPTION
fixes #127 

Drop support for [firegento/fastsimpleimport](https://github.com/firegento/FireGento_FastSimpleImport2) `1.3.4` and require `^2.0`