### PR TITLE
Fix the return type for Commands in symfony console in v5.4.24

### DIFF
--- a/Console/Command/ListCommand.php
+++ b/Console/Command/ListCommand.php
@@ -35,7 +35,7 @@ class ListCommand extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return void
+     * @return int
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -52,6 +52,8 @@ class ListCommand extends Command
             }
         } catch (ConfiguratorAdapterException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
         }
+        return Command::SUCCESS;
     }
 }

--- a/Console/Command/RunCommand.php
+++ b/Console/Command/RunCommand.php
@@ -64,7 +64,7 @@ class RunCommand extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return void
+     * @return int
      * @SuppressWarnings(PHPMD)
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -105,6 +105,8 @@ class RunCommand extends Command
             }
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
         }
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
Console commands cannot have a null return type in Magento 2.4.6 due to the updated symfony console component and must return a valid exit code. 