### PR TITLE
Fix some breaking changes from dependency

### DIFF
--- a/Component/Product/Image.php
+++ b/Component/Product/Image.php
@@ -207,11 +207,12 @@ class Image
      */
     public function getFileDirectory(\Magento\Framework\Filesystem\Directory\WriteInterface $file)
     {
-        $configurationValue = $this->importerConfig->getImportFileDir();
-        if (!empty($configurationValue)) {
-            return $file->getRelativePath($configurationValue);
+        try {
+            $configurationValue = $this->importerConfig->getImportFileDir();
+             return $file->getRelativePath($configurationValue);
+        } catch (\TypeError $e) {
+            return $file->getRelativePath('import');
         }
-        return $file->getRelativePath('import');
     }
 
     /**

--- a/Component/Product/Validator.php
+++ b/Component/Product/Validator.php
@@ -125,7 +125,7 @@ class Validator
     {
         $failedRows = [];
         // Creates a validation model and runs the import data through so we can find which rows would fail
-        $validation = $import->createImportModel();
+        $validation = $import->getImportModel();
         $validationSource = $this->importAdapterFactory->create([
             'data' => $importLines,
             'multipleValueSeparator' => Products::SEPARATOR


### PR DESCRIPTION
firegento/fastsimpleimport >=2.0.0 has a diff API.

One commit, fix a method name change:

```php
Call to undefined method FireGento\FastSimpleImport\Model\Importer::createImportModel()#0 /app/vendor/ctidigital/magento2-configurator/Component/Product/Validator.php(113): CtiDigital\Configurator\Component\Product\Validator->getImportRowFailures(Object(FireGento\FastSimpleImport\Model\Importer), Array)
```

The other a Typecasting error:
```php
Return value of FireGento\FastSimpleImport\Model\Config::getImportFileDir() must be of the type string, null returned#0 /app/vendor/ctidigital/magento2-configurator/Component/Product/Image.php(210): FireGento\FastSimpleImport\Model\Config->getImportFileDir()
```