### PR TITLE
Do not log info messages when verbosity is quiet

### DIFF
--- a/Console/Command/ListCommand.php
+++ b/Console/Command/ListCommand.php
@@ -52,8 +52,8 @@ class ListCommand extends Command
             }
         } catch (ConfiguratorAdapterException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
-            return Command::FAILURE;
+            return 1;
         }
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/Console/Command/RunCommand.php
+++ b/Console/Command/RunCommand.php
@@ -105,8 +105,8 @@ class RunCommand extends Command
             }
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
-            return Command::FAILURE;
+            return 1;
         }
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/Model/Logging.php
+++ b/Model/Logging.php
@@ -57,6 +57,8 @@ class Logging implements LoggerInterface
 
     public function logInfo($message, $nest = 0)
     {
-        $this->log($message, $this::LEVEL_INFO, $nest);
+        if ($this->level > OutputInterface::VERBOSITY_QUIET) {
+            $this->log($message, $this::LEVEL_INFO, $nest);
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "phpunit/phpunit": "^6.2",
     "magento/magento-coding-standard": "5"
   },
-  "version": "3.2.0",
+  "version": "3.2.1",
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "phpunit/phpunit": "^6.2",
     "magento/magento-coding-standard": "5"
   },
-  "version": "3.1.4",
+  "version": "3.2.0",
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": {


### PR DESCRIPTION
Depending on the module and exact situation config settings can contain sensitive information which is outputted to the console. As this is an info message there is no way to supress this by default.

Only log info messages when verbosity is not set to quiet to allow suppression